### PR TITLE
Blending support

### DIFF
--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -115,4 +115,5 @@ type Model interface {
 	Update(float64)
 	Export(string)
 	CollideTestWithSphere(*coldet.Sphere) bool
+	IsTransparent() bool
 }

--- a/pkg/model/README.md
+++ b/pkg/model/README.md
@@ -1,6 +1,6 @@
 # Model
 
-The purpose of this package, to gather the mashes that are connected to the same object (eg a composite object - a lamp with pole, and bulb). The meshes of a model are moving together, they are rotating, in the same time.
+The purpose of this package, to gather the mashes that are connected to the same object (eg a composite object - a lamp with pole, and bulb). The meshes of a model are moving together, they are rotating, in the same time. The model contains a transparency flag, that can be used to prevent the early drawing.
 
 ## Bug model
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -162,6 +162,11 @@ func (m *Model) SetTransparent(t bool) {
 	m.transparent = t
 }
 
+// IsTransparent function returns the transparent flag.
+func (m *Model) IsTransparent() bool {
+	return m.transparent
+}
+
 // CollideTestWithSphere is the collision detection function for items in this mesh vs sphere.
 func (m *BaseModel) CollideTestWithSphere(boundingSphere *coldet.Sphere) bool {
 	for i, _ := range m.meshes {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -11,7 +11,8 @@ import (
 )
 
 type Model struct {
-	meshes []interfaces.Mesh
+	meshes      []interfaces.Mesh
+	transparent bool
 }
 type BaseModel struct {
 	Model
@@ -61,13 +62,15 @@ func (m *BaseModel) Update(dt float64) {
 }
 func newModel() *Model {
 	return &Model{
-		meshes: []interfaces.Mesh{},
+		meshes:      []interfaces.Mesh{},
+		transparent: false,
 	}
 }
 func newCDModel() *BaseCollisionDetectionModel {
 	return &BaseCollisionDetectionModel{
 		Model{
-			meshes: []interfaces.Mesh{},
+			meshes:      []interfaces.Mesh{},
+			transparent: false,
 		},
 	}
 }
@@ -152,6 +155,11 @@ func (m *Model) RotateZ(angleDeg float32) {
 			m.meshes[i].RotatePosition(angleDeg, mgl32.Vec3{0.0, 0.0, 1.0})
 		}
 	}
+}
+
+// SetTransparent function updates the transparent flag.
+func (m *Model) SetTransparent(t bool) {
+	m.transparent = t
 }
 
 // CollideTestWithSphere is the collision detection function for items in this mesh vs sphere.

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -42,6 +42,20 @@ func TestAddMesh(t *testing.T) {
 		}
 	}
 }
+func TestSetTransparent(t *testing.T) {
+	model := New()
+	if model.transparent != false {
+		t.Error("Invalid initial transparent value. It should be false.")
+	}
+	model.SetTransparent(true)
+	if model.transparent != true {
+		t.Error("Invalid updated transparent value. It should be true.")
+	}
+	model.SetTransparent(false)
+	if model.transparent != false {
+		t.Error("Invalid updated transparent value. It should be false.")
+	}
+}
 func TestDraw(t *testing.T) {
 	func() {
 		defer func() {

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -56,6 +56,20 @@ func TestSetTransparent(t *testing.T) {
 		t.Error("Invalid updated transparent value. It should be false.")
 	}
 }
+func TestIsTransparent(t *testing.T) {
+	model := New()
+	if model.IsTransparent() != false {
+		t.Error("Invalid initial transparent value. It should be false.")
+	}
+	model.SetTransparent(true)
+	if model.IsTransparent() != true {
+		t.Error("Invalid updated transparent value. It should be true.")
+	}
+	model.SetTransparent(false)
+	if model.IsTransparent() != false {
+		t.Error("Invalid updated transparent value. It should be false.")
+	}
+}
 func TestDraw(t *testing.T) {
 	func() {
 		defer func() {

--- a/pkg/model/room.go
+++ b/pkg/model/room.go
@@ -210,6 +210,7 @@ func NewTextureRoom(position mgl32.Vec3, glWrapper interfaces.GLWrapper) *Room {
 	m.AddMesh(frontWallMain3)
 	m.AddMesh(frontWallMain4)
 	m.AddMesh(window)
+	m.SetTransparent(true)
 	return &Room{BaseCollisionDetectionModel: *m, doorState: _DOOR_OPENED, currentAnimationTime: 0}
 }
 


### PR DESCRIPTION
Make transparent, non transparent models distinguishable.
Duplicate draw circle, first draw non transparent models, then the transparent ones.
resolves #37 