### PR TITLE
Set uniforms for active screen also

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -236,6 +236,9 @@ func (a *Application) SetUniformFloat(key string, value float32) {
 	for i, _ := range a.screens {
 		a.screens[i].SetUniformFloat(key, value)
 	}
+	if a.activeScreen != nil {
+		a.activeScreen.SetUniformFloat(key, value)
+	}
 }
 
 // SetUniformVector loops on screens and sets the given mgl32.Vec3 value to the given string key in
@@ -243,6 +246,9 @@ func (a *Application) SetUniformFloat(key string, value float32) {
 func (a *Application) SetUniformVector(key string, value mgl32.Vec3) {
 	for i, _ := range a.screens {
 		a.screens[i].SetUniformVector(key, value)
+	}
+	if a.activeScreen != nil {
+		a.activeScreen.SetUniformVector(key, value)
 	}
 }
 

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -162,6 +162,8 @@ func TestSetUniformFloat(t *testing.T) {
 		key := "testname"
 		value := float32(2.2)
 		app.SetUniformFloat(key, value)
+		app.ActivateScreen(s)
+		app.SetUniformFloat(key, value)
 	}()
 }
 func TestSetUniformVector(t *testing.T) {
@@ -177,6 +179,8 @@ func TestSetUniformVector(t *testing.T) {
 		app.AddScreen(s)
 		key := "testname"
 		value := mgl32.Vec3{42.0, 0.0, 0.0}
+		app.SetUniformVector(key, value)
+		app.ActivateScreen(s)
 		app.SetUniformVector(key, value)
 	}()
 }


### PR DESCRIPTION
It fixes a bug in the system. After the screen has been set to app screen, the time wasn't changed, due to the active screen was missing from the update circle.